### PR TITLE
Fixed autodoc of aw modules by requiring them

### DIFF
--- a/api-reference.rst
+++ b/api-reference.rst
@@ -54,7 +54,7 @@ aw_server
 aw_server.api
 ^^^^^^^^^^^^^
 
-The `ServerAPI` class contains the basic API methods, these methods are primarily called from RPC layers such as the one found in :code:`aw_server.rest`.
+The :code:`ServerAPI` class contains the basic API methods, these methods are primarily called from RPC layers such as the one found in :code:`aw_server.rest`.
 
 .. automodule:: aw_server.api
    :members: ServerAPI

--- a/conf.py
+++ b/conf.py
@@ -19,11 +19,6 @@
 
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../aw-server'))
-sys.path.insert(0, os.path.abspath('../aw-core'))
-sys.path.insert(0, os.path.abspath('../aw-client'))
-sys.path.insert(0, os.path.abspath('../aw-watcher-afk'))
-sys.path.insert(0, os.path.abspath('../aw-watcher-window'))
 
 # Other imports
 

--- a/installing-from-source.rst
+++ b/installing-from-source.rst
@@ -43,7 +43,6 @@ It is recommended to use a virtualenv in order to avoid polluting your system wi
 
 .. code-block:: sh
 
-    pip3 install --user virtualenv  # Assuming you don't already have it, you might want to use your systems package manager instead.
     python3 -m venv venv
 
 Now activate the virtualenv in your current shell session:

--- a/rest.rst
+++ b/rest.rst
@@ -36,8 +36,8 @@ Buckets API
 The most common API used by ActivityWatch clients is the API providing read and append access buckets.
 Buckets are data containers used to group data together which shares some metadata (such as client type, hostname or location).
 
-Get
-^^^
+Get Bucket Metadata
+^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: shell
 

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -1,5 +1,10 @@
 # Requirements for ReadTheDocs
 
+# activitywatch repos
+git+https://github.com/ActivityWatch/aw-core.git@master#egg=aw-core
+git+https://github.com/ActivityWatch/aw-server.git@master#egg=aw-server
+git+https://github.com/ActivityWatch/aw-client.git@master#egg=aw-client
+
 # aw-core
 appdirs
 python-json-logger


### PR DESCRIPTION
- Sphinx automodule calls were failing in `api-reference.rst`, this
  was fixed by adding the necessary aw modules to
  rtd-requirements.txt
- Unnecessary instruction to install of virtualenv was removed