### PR TITLE
Use environment variables in Windows paths

### DIFF
--- a/getting-started.rst
+++ b/getting-started.rst
@@ -43,8 +43,8 @@ Configuration files for ActivityWatch can be found at the following default loca
 
 - Unix: :code:`~/.config/activitywatch` or the path defined by the :code:`$XDG_CONFIG_HOME` environment variable.
 - Mac OS X: :code:`~/Library/Application\ Support/activitywatch/`
-- Windows 7 & 10: :code:`C:\Users\<username>\AppData\Local\activitywatch\activitywatch`
-- Windows XP: :code:`C:\Documents and Settings\<username>\Application Data\activitywatch\activitywatch`
+- Windows Vista+: :code:`%LocalAppData%\activitywatch\activitywatch`
+- Windows XP: :code:`%USERPROFILE%\Application Data\activitywatch\activitywatch`
 
 Config options for the server, client, and default watchers are listed below:
 

--- a/getting-started.rst
+++ b/getting-started.rst
@@ -43,8 +43,7 @@ Configuration files for ActivityWatch can be found at the following default loca
 
 - Unix: :code:`~/.config/activitywatch` or the path defined by the :code:`$XDG_CONFIG_HOME` environment variable.
 - Mac OS X: :code:`~/Library/Application\ Support/activitywatch/`
-- Windows Vista+: :code:`%LocalAppData%\activitywatch\activitywatch`
-- Windows XP: :code:`%USERPROFILE%\Application Data\activitywatch\activitywatch`
+- Windows: :code:`%LocalAppData%\activitywatch\activitywatch`
 
 Config options for the server, client, and default watchers are listed below:
 


### PR DESCRIPTION
This better mimics the Unix like `~` usage for the others, removing the need for "variable replacement" by the user. Paths in this format are supported in a lot of places in Windows, such as File Explorer, the classic Run dialog, and traditional CMD.EXE. PowerShell users should already know how to convert these already, so not including that here. (For reference: `%USERPROFILE%` is supported as `~` in PowerShell, and `$env:LocalAppData` is the variable format for `%LocalAppData%`.)