### PR TITLE
fix start.sh script

### DIFF
--- a/getting-started.rst
+++ b/getting-started.rst
@@ -90,9 +90,9 @@ As an alternative for users of GNOME 3 and other DEs that don't support app tray
 
   cd ~/.local/opt/activitywatch         # Put your ActivityWatch install folder here
 
-  ./aw-server &
-  ./aw-watcher-afk &
-  ./aw-watcher-window &                 # you can add --exclude-title here to exclude window title tracking for this session only
+  ./aw-server/aw-server &
+  ./aw-watcher-afk/aw-watcher-afk &
+  ./aw-watcher-window/aw-watcher-window &                 # you can add --exclude-title here to exclude window title tracking for this session only
 
   notify-send "ActivityWatch started"   # Optional, sends a notification when ActivityWatch is started
 


### PR DESCRIPTION
I downloaded activitywatch-v0.8.3-linux-x86_64.zip and to use the `start.sh` script I had to adjust as in this commit