### PR TITLE
docs: updated autostart section in getting started guide

### DIFF
--- a/getting-started.rst
+++ b/getting-started.rst
@@ -53,7 +53,7 @@ Autostart
 .. note::
     Autostart is set up automatically by the Windows installer and for Arch Linux by the AUR package (if your desktop environment supports `XDG Autostart <https://wiki.archlinux.org/index.php/XDG_Autostart>`_).
 
-You might want to make ``aw-qt`` start automatically on login using the
+You might want to make ``aw-qt`` start automatically on login using the .profile or .xinitrc files.
 We hope to automate this for you in the future but for now you'll have to do it yourself.
 Searching the web for "autostart application <your operating system>" should get you some good results that don't take long.
 

--- a/getting-started.rst
+++ b/getting-started.rst
@@ -53,9 +53,8 @@ Autostart
 .. note::
     Autostart is set up automatically by the Windows installer and for Arch Linux by the AUR package (if your desktop environment supports `XDG Autostart <https://wiki.archlinux.org/index.php/XDG_Autostart>`_).
 
-You might want to make ``aw-qt`` start automatically on login using the .profile or .xinitrc files.
-We hope to automate this for you in the future but for now you'll have to do it yourself.
-Searching the web for "autostart application <your operating system>" should get you some good results that don't take long.
+You probably want to make ActivityWatch start automatically on login using your operating systems autostart settings.
+For some installation methods (Windows installer, AUR package) this is done automatically, but if you don't use those methods you'll have to do it yourself. Searching the web for "autostart application <your operating system>" should get you some good results that don't take long. You want to start the ``aw-qt`` executable in the application directory.
 
 Config
 ======


### PR DESCRIPTION
I'm not sure I'm adding the right locations for aw-qt autostart.  But in any case this sentence was unfinished.