### PR TITLE
Add NicoWeio/aw-watcher-atom to list of code editor watchers

### DIFF
--- a/watchers.rst
+++ b/watchers.rst
@@ -30,6 +30,7 @@ Watches the actively edited file and associated metadata like path, language, an
  - :gh:`LaggAt/ActivityWatchVS` - Visual Studio extension, by :gh-user:`LaggAt`
  - :gh:`pascalwhoop/aw-idea` - (WIP) JetBrains IntelliJ IDEA/PyCharm/WebStorm/etc extension forked from wakatime, by :gh-user:`pascalwhoop`
  - :gh:`kostasdizas/aw-watcher-sublime` - Sublime Text 3, by :gh-user:`kostasdizas`
+ - :gh:`NicoWeio/aw-watcher-atom` - Atom, by :gh-user:`NicoWeio`
 
 Media watchers
 --------------


### PR DESCRIPTION
I just built a watcher package for Atom code editor. Would you include it in your list?

https://github.com/NicoWeio/aw-watcher-atom
https://atom.io/packages/aw-watcher-atom