### PR TITLE
docs: Adding an item in the dependency list of installing-from-source.rst

### DIFF
--- a/src/installing-from-source.rst
+++ b/src/installing-from-source.rst
@@ -33,7 +33,6 @@ You need:
 - Node 8 or higher, check with :code:`node -v` and :code:`npm -v` (required to build the web UI)
 - (Optional) Rust nightly and cargo, check with :code:`rustc -V` and :code:`cargo -V` (for building aw-server-rust)
 
-
 Using a virtualenv
 ------------------
 

--- a/src/installing-from-source.rst
+++ b/src/installing-from-source.rst
@@ -29,7 +29,7 @@ Checking dependencies
 
 You need:
 
-- Python 3.6 or later and Poetry, check with :code:`python3 -V` and :code:`poetry -V` (required to build the core components)
+- Python 3.6 or later and Poetry, check with :code:`python3 -V` and :code:`poetry -V` (required to build the core components, can be installed like this: :code:`python3 -m pip install poetry`)
 - Node 8 or higher, check with :code:`node -v` and :code:`npm -v` (required to build the web UI)
 - (Optional) Rust nightly and cargo, check with :code:`rustc -V` and :code:`cargo -V` (for building aw-server-rust)
 


### PR DESCRIPTION
I was curious about this project and decided I wanted to build it from the source.
I followed all the instructions but the ` make install ` failed :

```
(venv) ➜  activitywatch git:(master) make build
if [ -e "aw-core/.git" ]; then \
	echo "Submodules seem to already be initialized, continuing..."; \
else \
	git submodule update --init --recursive; \
fi
Submodules seem to already be initialized, continuing...
make --directory=aw-core build
make[1]: Entering directory '/home/riha/dev/garage/activitywatch/aw-core'
poetry install
make[1]: poetry: Command not found
make[1]: *** [Makefile:4: build] Error 127
make[1]: Leaving directory '/home/riha/dev/garage/activitywatch/aw-core'
make: *** [Makefile:29: build] Error 2

```

I realized I needed to have **Poetry** installed.
After installing Poetry, building was no problemo. 
I figured it is worth mentioning Poetry as a dependency for the build to be successful. 

Background on the system I was using for the source build:

- OS: Ubuntu 19.10, Linux kernel 5.3.0