### PR TITLE
docs: when building, Python should be 3.6 or 3.7

### DIFF
--- a/src/installing-from-source.rst
+++ b/src/installing-from-source.rst
@@ -29,7 +29,7 @@ Checking dependencies
 
 You need:
 
-- Python 3.6 or later and Poetry, check with :code:`python3 -V` and :code:`poetry -V` (required to build the core components, can be installed like this: :code:`python3 -m pip install poetry`)
+- Python 3.6 or 3.7 and Poetry, check with :code:`python3 -V` and :code:`poetry -V` (required to build the core components, can be installed like this: :code:`python3 -m pip install poetry`)
 - Node 8 or higher, check with :code:`node -v` and :code:`npm -v` (required to build the web UI)
 - (Optional) Rust nightly and cargo, check with :code:`rustc -V` and :code:`cargo -V` (for building aw-server-rust)
 


### PR DESCRIPTION
* with 3.8 it errors because of sip
* related issue: https://github.com/ActivityWatch/activitywatch/issues/433