### PR TITLE
docs: improvements to aw-client example

### DIFF
--- a/src/examples/query_client.py
+++ b/src/examples/query_client.py
@@ -6,6 +6,8 @@ from datetime import datetime, timedelta, timezone
 from aw_core.models import Event
 from aw_client import ActivityWatchClient
 
+# We'll run with testing=True so we don't mess up any production instance.
+# Make sure you've started aw-server with the `--testing` flag as well.
 client = ActivityWatchClient("test-client", testing=True)
 
 now = datetime.now(timezone.utc)

--- a/src/examples/querying-data.rst
+++ b/src/examples/querying-data.rst
@@ -1,12 +1,12 @@
 Querying Data
 =============
 
-There are a couple of ways to query data in activitywatch.
+There are a couple of ways to query data in ActivityWatch.
 
 aw-server supplies a "/query" endpoint (also accessible via aw-client's query method) which supplies a basic scripting language which you can utilize to do transformations on the server-side.
 This option is good for basic analysis and for lightweight clients (such as aw-webui).
 
-Another option is to fetch events from the "/buckets/bucketname/events" endpoint (also accessible via aw-client's get_events method) and either program your own transformations or use transformation methods available in the aw-analysis python library (which includes all transformations available in the query endpoint). This require a lot of more work since you will likely have to reprogram transformations already available in the query API, but on the other hand it is much more flexible.
+Another option is to fetch events from the "/buckets/bucketname/events" endpoint (also accessible via aw-client's get_events method) and either program your own transformations or use transformation methods available in the aw-analysis python library (which includes all transformations available in the query endpoint). This requires a lot of more work since you will likely have to reprogram transformations already available in the query API, but on the other hand it is much more flexible.
 
 
 Writing a Query

--- a/src/examples/querying-data.rst
+++ b/src/examples/querying-data.rst
@@ -61,6 +61,8 @@ Example including aw-client:
     This is an example of how you can do analysis and aggregation with the query method in Python with aw-client.
     You probably need to install the client library by following the instructions in its `repository <https://github.com/ActivityWatch/aw-client>`_.
 
+	.. note:: This example runs the client in *testing* mode, which means that it will try to connect to an aw-server in testing mode on the port 5666 instead of the normal 5600.
+
     .. literalinclude:: query_client.py
 
 Fetching Raw Events

--- a/src/examples/querying-data.rst
+++ b/src/examples/querying-data.rst
@@ -58,7 +58,8 @@ Example combining window and AFK events:
         RETURN = events;
 
 Example including aw-client:
-    This is an example of how you can do analysis and aggregation with the query method in python with aw-client
+    This is an example of how you can do analysis and aggregation with the query method in Python with aw-client.
+    You probably need to install the client library by following the instructions in its `repository <https://github.com/ActivityWatch/aw-client>`_.
 
     .. literalinclude:: query_client.py
 

--- a/src/examples/writing-watchers.rst
+++ b/src/examples/writing-watchers.rst
@@ -3,7 +3,7 @@ Writing your first watcher
 
 Writing watchers for ActivityWatch is pretty easy, all you need is the :code:`aw-client` library.
 
-.. note:: These examples runs the client in *testing* mode, which means that it will try to connect to a aw-server in testing mode on the port 5666 instead of the normal 5600.
+.. note:: These examples run the client in *testing* mode, which means that it will try to connect to an aw-server in testing mode on the port 5666 instead of the normal 5600.
 
 Minimal client
 --------------
@@ -25,11 +25,11 @@ Reference client
 Below is a example of a watcher with more in-depth comments.
 This example will describe how to:
 
-* how to create buckets
-* how to send events by heartbeats
-* how to insertion events without heartbeats
-* how to do syncronous as well as asyncronous requests
-* fetch events from a aw-server bucket
+* create buckets
+* send events by heartbeats
+* insert events without heartbeats
+* do synchronous as well as asyncronous requests
+* fetch events from an aw-server bucket
 * delete buckets
 
 .. literalinclude:: client.py

--- a/src/getting-started.rst
+++ b/src/getting-started.rst
@@ -44,7 +44,7 @@ The aw-qt application is the easiest way to use ActivityWatch. It creates a tray
 
 If you've installed by extracting a zip archive, simply run the ``./aw-qt`` binary in the installation directory (either from your terminal or on Windows by double-clicking). You now should see an icon appear in your system tray.
 
-You should now also have the web interface running at `<localhost:5600>`_ and will in a few minutes be able to view your data in the Activity view!
+You should now also have the web interface running at `<localhost:5600>`_ and within a few minutes be able to view your data in the Activity view!
 
 If you want more advanced ways to run ActivityWatch (including running it without aw-qt), check out the "Running" section of `installing-from-source`.
 
@@ -52,7 +52,7 @@ If you want more advanced ways to run ActivityWatch (including running it withou
    If you are running GNOME 3 or another desktop environment that does not support system trays, or if for some reason Qt can't be used on your machine, read `Running on GNOME`.
 
 .. note::
-   If you are using a proxy ActivityWatch might not work out of the box. To fix this you can set the environment variable ``NO_PROXY`` to include ``127.0.0.1`` before starting aw-qt. How to set an environment variable depends on your operating system, use Google if you are unsure how to do this.
+   If you are using a proxy ActivityWatch might not work out of the box. To fix this you can set the environment variable ``NO_PROXY`` to include ``127.0.0.1`` before starting aw-qt. How to set an environment variable depends on your operating system; use Google if you are unsure how to do this.
 
 Autostart
 =========
@@ -60,5 +60,5 @@ Autostart
 .. note::
     Autostart is set up automatically by the Windows installer and for Arch Linux by the AUR package (if your desktop environment supports `XDG Autostart <https://wiki.archlinux.org/index.php/XDG_Autostart>`_).
 
-You probably want to make ActivityWatch start automatically on login using your operating systems autostart settings.
+You probably want to make ActivityWatch start automatically on login using your operating system's autostart settings.
 For some installation methods (Windows installer, AUR package) this is done automatically, but if you don't use those methods you'll have to do it yourself. Searching the web for "autostart application <your operating system>" should get you some good results that don't take long. You want to start the ``aw-qt`` executable in the application directory.


### PR DESCRIPTION
I wanted to do a little project using data from ActivityWatch, and noticed that the examples regarding _aw-client_ are incomplete or outdated. 
For now, I only added a note with a link to the _aw-client_ repo, because it wasn't immediately obvious that _aw-client_ would need to be manually installed. (At least that's what I assumed, because for me, it doesn't work without.)
But there are other problems like strings instead of datetimes being passed to `client.query`, which leads to errors.
Also, it should be emphasized that in the example, _aw-client_ tries to connect to a testing instance (if I understood that correctly).

Since I'm only just getting into it, I'm not sure if I am the right person to edit the documentation, but I thought I'd give it a try.

---

I found some unrelated typos while browsing the docs, which I also fixed in this PR.