### PR TITLE
CI: upload build directory as artifact

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,3 +25,8 @@ jobs:
     - name: Build docs
       run: |
         poetry run make html
+    - name: Upload build
+      uses: actions/upload-artifact@v2-preview
+      with:
+        name: build
+        path: _build


### PR DESCRIPTION
How about uploading build artifacts as in [aw-webui](https://github.com/ActivityWatch/aw-webui/commit/ba2374bdf7c580412837022432d41404b4332d1d)?

Edit: As my proposed updated workflow already ran on this PR, I can report that the size of the upload is 7 megabytes.