### PR TITLE
Documentation of activity watch monitoring employees plus minor changes in other files

### DIFF
--- a/src/architecture.rst
+++ b/src/architecture.rst
@@ -15,7 +15,7 @@ The illustration below is a graph of the fundamental dependencies between projec
 Server
 ------
 
-Known as aw-server, it handles storage and retrieval of all activities/entries in buckets. Usually there exists one bucket per watcher.
+Known as :gh-aw:`aw-server`, it handles storage and retrieval of all activities/entries in buckets. Usually there exists one bucket per watcher.
 
 The server also hosts the Web UI (aw-webui) which does all communication with the server using the REST API.
 

--- a/src/architecture.rst
+++ b/src/architecture.rst
@@ -3,10 +3,12 @@ Architecture
 
 Here we hope to clarify the architecture of ActivityWatch for you. Please file an issue or pull request if you think something is missing.
 
+.. contents::
+
 Dependency graph
 ----------------
 
-The below is a graph of the fundamental dependencies between projects, these do not reflect the folder structure.
+The illustration below is a graph of the fundamental dependencies between projects, these do not reflect the folder structure.
 
 .. graphviz:: dependency.dot
 

--- a/src/buckets-and-events.rst
+++ b/src/buckets-and-events.rst
@@ -1,6 +1,8 @@
 Data model
 ==========
 
+.. contents::
+
 Buckets
 -------
 
@@ -87,8 +89,8 @@ currentwindow
 ~~~~~~~~~~~~~
 
 .. note::
-	There are suggestions to improve/change this format
-	(see :issue:`201`)
+    There are suggestions to improve/change this format
+    (see :issue:`201`)
 
 .. code-block:: javascript
 
@@ -101,8 +103,8 @@ afkstatus
 ~~~~~~~~~
 
 .. note::
-	There are suggestions to improve/change this format
-	(see :issue:`201`)
+    There are suggestions to improve/change this format
+    (see :issue:`201`)
 
 .. code-block:: javascript
 

--- a/src/installing-from-source.rst
+++ b/src/installing-from-source.rst
@@ -41,12 +41,12 @@ You need:
 
 **Commands which should work before building:**
 
-- :code:`git -v`
-- :code:`make -v`
-- :code:`python -V`
-- :code:`poetry -v`
-- :code:`node -v` / :code:`npm -v`
-- :code:`rustc -V` / :code:`cargo -v`
+- :code:`git -v` or :code:`git --version`
+- :code:`make -v` or :code:`make --version`
+- :code:`python -V` or :code:`python --version`
+- :code:`poetry -v` or :code:`poetry --version`
+- :code:`node -v` / :code:`npm -v` or :code:`node --version` / :code:`npm --version`
+- :code:`rustc -V` / :code:`cargo -v` or :code:`rustc --version` / :code:`cargo --version`
 - :code:`7z` (optional)
 
 If any of these don't work, make sure you've correctly installed them and have them in your PATH variable.

--- a/src/security.rst
+++ b/src/security.rst
@@ -5,6 +5,7 @@ ActivityWatch deals with highly sensitive data, and the security of it is theref
 
 We do try our best to keep security in mind. In this section of the documentation we'll outline some important security considerations, including risks and possible improvements.
 
+.. contents::
 
 ActivityWatch is only as secure as your system
 ----------------------------------------------

--- a/src/usage.rst
+++ b/src/usage.rst
@@ -1,0 +1,70 @@
+Usage
+============
+
+Here we hope to clarify the founder's designed usage of ActivityWatch.
+
+.. contents::
+
+Intended Use of ActivityWatch
+----------------
+
+The `vision <https://github.com/ActivityWatch/activitywatch/issues/236>`_ of ActivityWatch has always been for the betterment of the user.
+May it be for personal, business, or solely research.
+
+
+Monitoring of Unaware Individuals Using ActivityWatch
+------
+
+In line with ActivityWatch's vision, the users of ActivityWatch should have full consent when they utilize this software.
+
+Data privacy is a right to each individual, and the use of this program to monitor people without their knowledge will go against the design of ActivityWatch.
+
+
+Employee Monitoring Using ActivityWatch
+--------------------------------------------
+
+The monitoring of employees to check their activities can cause harm to workers and is highly illegal employee surveillance.
+
+The ActivityWatch team is currently planning implementations for an enterprise feature (presently called Report) for the program.
+
+
+Report Feature
+---------------
+
+The `plans <https://github.com/ActivityWatch/activitywatch/issues/233>`_ for the Report feature would be a whitelisting system. Users can whitelist which activities to report,
+preventing personal data from being leaked.
+
+It would also relay the employers with only work-related activities.
+
+Libraries
+---------
+
+Some of the logic of ActivityWatch is shared across the server and clients, for these cases we moved some logic into separate libraries.
+
+aw-core
+^^^^^^^
+
+The aw-core library contains many of the essential parts of ActivityWatch, notably:
+
+ - The `buckets-and-events`
+ - The datastore layer
+ - Event transformation and queries
+ - Utilities (configuration, logging, decorators)
+
+aw-client
+^^^^^^^^^
+
+Writing these clients is something we've tried to make as easy as possible by creating client libraries with a clear API.
+A client could both be a watcher which sends data as well as a visualizer which fetches and presents data from the aw-server.
+
+Currently the primary client library is written in Python (known simply as aw-client) but a client library written in JavaScript is on the way and is expected to have the same level of support in the future.
+
+ - :gh-aw:`aw-client` (Python)
+ - :gh-aw:`aw-client-js` (TypeScript/JavaScript, beta)
+ - :gh-aw:`aw-client-rust` (Rust, work in progress)
+
+aw-analysis
+^^^^^^^^^^^
+
+There are also plans to create a library called :gh-aw:`aw-analysis` to aid in
+different types of analysis and transformation one might want to make using ActivityWatch data.

--- a/src/usage.rst
+++ b/src/usage.rst
@@ -35,36 +35,3 @@ The `plans <https://github.com/ActivityWatch/activitywatch/issues/233>`_ for the
 preventing personal data from being leaked.
 
 It would also relay the employers with only work-related activities.
-
-Libraries
----------
-
-Some of the logic of ActivityWatch is shared across the server and clients, for these cases we moved some logic into separate libraries.
-
-aw-core
-^^^^^^^
-
-The aw-core library contains many of the essential parts of ActivityWatch, notably:
-
- - The `buckets-and-events`
- - The datastore layer
- - Event transformation and queries
- - Utilities (configuration, logging, decorators)
-
-aw-client
-^^^^^^^^^
-
-Writing these clients is something we've tried to make as easy as possible by creating client libraries with a clear API.
-A client could both be a watcher which sends data as well as a visualizer which fetches and presents data from the aw-server.
-
-Currently the primary client library is written in Python (known simply as aw-client) but a client library written in JavaScript is on the way and is expected to have the same level of support in the future.
-
- - :gh-aw:`aw-client` (Python)
- - :gh-aw:`aw-client-js` (TypeScript/JavaScript, beta)
- - :gh-aw:`aw-client-rust` (Rust, work in progress)
-
-aw-analysis
-^^^^^^^^^^^
-
-There are also plans to create a library called :gh-aw:`aw-analysis` to aid in
-different types of analysis and transformation one might want to make using ActivityWatch data.


### PR DESCRIPTION
Tackles documentation in General:
- Document how ActivityWatch is not designed to monitor employees.
-- We do not want people to be forced to use ActivityWatch in a way where their data is stored by/sent directly to their employer.
-- However, we might implement a "report" feature (Implement reporting #233), which (imo) is the privacy-aware way to approach 
    the issue.