### PR TITLE
Additional File for Monitoring Employee

### DIFF
--- a/src/installing-from-source.rst
+++ b/src/installing-from-source.rst
@@ -28,9 +28,9 @@ Checking dependencies
 You need:
 
 - `Git <https://git-scm.com/downloads>`_
-- `Python 3.7 to 3.9 <https://www.python.org/downloads/>`_, check with :code:`python3 -V` (required to build the core components)
-- `Poetry <https://python-poetry.org/docs/#installation>`_, check with :code:`poetry -V` (can be installed like this: :code:`python3 -m pip install poetry`)
-- `Node 12 or higher <https://www.npmjs.com/get-npm>`_, check with :code:`node -v` and :code:`npm -v` (required to build the web UI)
+- `Python 3.7 to 3.9 <https://www.python.org/downloads/>`_, check with :code:`python --version` (required to build the core components)
+- `Poetry <https://python-poetry.org/docs/#installation>`_, check with :code:`poetry --version` (can be installed like this: :code:`python3 -m pip install poetry`)
+- `Node 12 or higher <https://nodejs.org/en/download/>`_, (recommended to download the LTS version), check with :code:`node --version` and :code:`npm --version` (required to build the web UI)
 - `Rust nightly <https://doc.rust-lang.org/cargo/getting-started/installation.html>`_ (nightly can be installed using :code:`rustup`), check with :code:`rustc -V` and :code:`cargo -V` (for building aw-server-rust)
 
 **For Windows users:**

--- a/src/usage.rst
+++ b/src/usage.rst
@@ -1,0 +1,37 @@
+Usage
+=====
+
+Here we hope to clarify the founder's designed usage of ActivityWatch.
+
+.. contents::
+
+Intended Use of ActivityWatch
+-----------------------------
+
+The `vision <https://github.com/ActivityWatch/activitywatch/issues/236>`_ of ActivityWatch has always been for the betterment of the user.
+May it be for personal, business, or solely research.
+
+
+Monitoring of Unaware Individuals Using ActivityWatch
+-----------------------------------------------------
+
+In line with ActivityWatch's vision, the users of ActivityWatch should have full consent when they utilize this software.
+
+Data privacy is a right to each individual, and the use of this program to monitor people without their knowledge will go against the design of ActivityWatch.
+
+
+Employee Monitoring Using ActivityWatch
+---------------------------------------
+
+The monitoring of employees to check their activities can cause harm to workers and is inline with illegal employee surveillance.
+
+To accomodate a monitoring feature for enterprises, the ActivityWatch team is currently planning implementations for a new feature (presently called Report) for the program.
+
+
+Report Feature
+--------------
+
+The ` proposed plans <https://github.com/ActivityWatch/activitywatch/issues/233>`_ for the Report feature would be a whitelisting system. Users can whitelist activities they deemed private to report,
+preventing personal data from being leaked.
+
+It would also relay the employers with only work-related activities.


### PR DESCRIPTION
Created usage.rst to tackle problem in [issue 528](https://github.com/ActivityWatch/activitywatch/issues/528):
_Document how ActivityWatch is not designed to monitor employees._

Content of usage.rst:
- Intended Use of ActivityWatch - has the vision of ActivityWatch
- Monitoring of Unaware Individuals Using ActivityWatch
- Employee Monitoring Using ActivityWatch
- Report Feature - [Proposed plan in issue 233](https://github.com/ActivityWatch/activitywatch/issues/233)


