### PR TITLE
docs: remove duplicate Sublime Text watcher

### DIFF
--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -29,8 +29,7 @@ Watches the actively edited file and associated metadata like path, language, an
  - :gh:`OlivierMary/aw-watcher-jetbrains` - JetBrains IntelliJ plugin, by :gh-user:`OlivierMary`.
  - :gh:`LaggAt/ActivityWatchVS` - Visual Studio extension, by :gh-user:`LaggAt`
  - :gh:`pascalwhoop/aw-idea` - (WIP) JetBrains IntelliJ IDEA/PyCharm/WebStorm/etc extension forked from wakatime, by :gh-user:`pascalwhoop`
- - :gh:`kostasdizas/aw-watcher-sublime` - Sublime Text 3, by :gh-user:`kostasdizas` (unmaintained)
- - :gh:`prplecake/aw-watcher-sublimetext` - Sublime Text 3, by :gh-user:`prplecake` (fork of aw-watcher-sublime above, maintained)
+ - :gh:`kostasdizas/aw-watcher-sublime` - Sublime Text 3, by :gh-user:`kostasdizas`, and others
  - :gh:`NicoWeio/aw-watcher-atom` - Atom, by :gh-user:`NicoWeio`
 
 Media watchers


### PR DESCRIPTION
Removes the (my) duplicate Sublime Text plugin added in #59.

kostasdizas/aw-watcher-sublime should be considered the one true ST watcher, and has been updated to be functionally equivalent to what I had rewritten. Plus, their's is the one in package control and ST seems to really try to minimize multiple similar packages, for good reason. 