### PR TITLE
docs: remove duplicate Sublime Text watcher

### DIFF
--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -29,8 +29,7 @@ Watches the actively edited file and associated metadata like path, language, an
 - :gh:`OlivierMary/aw-watcher-jetbrains` - JetBrains IntelliJ plugin, by :gh-user:`OlivierMary`.
 - :gh:`LaggAt/ActivityWatchVS` - Visual Studio extension, by :gh-user:`LaggAt`
 - :gh:`pascalwhoop/aw-idea` - (WIP) JetBrains IntelliJ IDEA/PyCharm/WebStorm/etc extension forked from wakatime, by :gh-user:`pascalwhoop`
-- :gh:`kostasdizas/aw-watcher-sublime` - Sublime Text 3, by :gh-user:`kostasdizas` (unmaintained)
-- :gh:`prplecake/aw-watcher-sublimetext` - Sublime Text 3, by :gh-user:`prplecake` (fork of aw-watcher-sublime above, maintained)
+- :gh:`kostasdizas/aw-watcher-sublime` - Sublime Text 3, by :gh-user:`kostasdizas`, and others
 - :gh:`NicoWeio/aw-watcher-atom` - Atom, by :gh-user:`NicoWeio`
 
 Media watchers


### PR DESCRIPTION
Not sure why this got undone, but this reapplies PR #75.

(I was the original author of that PR, but merged GitHub accounts. I'm the ghost in the aforementioned PR.)