### PR TITLE
docs(macos): add more detail to the macOS install instructions

### DIFF
--- a/src/getting-started.rst
+++ b/src/getting-started.rst
@@ -18,7 +18,7 @@ Installation
    .. group-tab:: macOS
 
       .. note::
-         macOS 10.15 (Catalina) introduced some complications for running ActivityWatch, see :issue:`334`.
+         macOS >10.15 (Catalina) introduced some complications for running ActivityWatch (privacy and application permissions), see :issue:`334` for post install steps needed to allow ActivityWatch to read the current active window / application (ActivityWatch shows window name and application name as `unknown` without these steps.
 
       Download the ``.dmg`` for the `latest release from GitHub <https://github.com/ActivityWatch/activitywatch/releases>`_ and drag the ``.app`` to your Applications folder as usual, then add it to your autostart applications.
 

--- a/src/getting-started.rst
+++ b/src/getting-started.rst
@@ -18,7 +18,7 @@ Installation
    .. group-tab:: macOS
 
       .. note::
-         macOS >10.15 (Catalina) introduced some complications for running ActivityWatch (privacy and application permissions), see :issue:`334` for post install steps needed to allow ActivityWatch to read the current active window / application (ActivityWatch shows window name and application name as `unknown` without these steps.
+         macOS >10.15 (Catalina) introduced some complications for running ActivityWatch (privacy and application permissions). See :issue:`334` for post-install steps needed to allow ActivityWatch to read the current active window / application (without these steps, ActivityWatch may not start and will show window and application names as `unknown`).
 
       Download the ``.dmg`` for the `latest release from GitHub <https://github.com/ActivityWatch/activitywatch/releases>`_ and drag the ``.app`` to your Applications folder as usual, then add it to your autostart applications.
 


### PR DESCRIPTION
I just setup the ActivityWatch on MacOS and I ran into the other issues outlined in #334.  I want to update the note to try to make it more clear that a new user still needs to work around this issue, bc Catalina was old when I checked the documentation I figured this was already taken care of and didn't get re-directed to the issue until some more google searching.

Lmk if you would prefer a writeup of [the steps](https://github.com/ActivityWatch/activitywatch/issues/334#issuecomment-1052392579) @may posted.  