### PR TITLE
Fix ActivityWatchClient AttributeError

### DIFF
--- a/src/examples/minimal_client.py
+++ b/src/examples/minimal_client.py
@@ -9,7 +9,7 @@ from aw_client import ActivityWatchClient
 # Make sure you've started aw-server with the `--testing` flag as well.
 client = ActivityWatchClient("test-client", testing=True)
 
-bucket_id = "{}_{}".format("test-client-bucket", client.hostname)
+bucket_id = "{}_{}".format("test-client-bucket", client.client_hostname)
 client.create_bucket(bucket_id, event_type="dummydata")
 
 shutdown_data = {"label": "some interesting data"}


### PR DESCRIPTION
Executing the `minimal_client.py` example will result in an unhandled exception being thrown.

```
    bucket_id = f"test-client-bucket_{client.hostname}"
AttributeError: 'ActivityWatchClient' object has no attribute 'hostname'
```

This adds the [correct attribute name](https://github.com/ActivityWatch/aw-client/blob/df8776c59000bb785542bd4fe4c37ff61f975420/aw_client/client.py#L76) for the client's hostname.