### PR TITLE
docs(watchers): add aw-watcher-mpv

### DIFF
--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -41,6 +41,7 @@ If you want to more accurately track media consumption.
 - :gh-aw:`aw-watcher-spotify` - (Beta) Uses the Spotify Web API to get the active track.
 - :gh-aw:`aw-watcher-chromecast` - (not working yet) Watches what is playing on you Chromecast device.
 - :gh-aw:`aw-watcher-openvr` - (not working yet) Watches active VR applications.
+- :gh:`RundownRhino/aw-watcher-mpv-sender` - (WIP) Watches mpv and reports the currently playing video.
 
 Other watchers
 --------------


### PR DESCRIPTION
Wrote [an AW watcher for mpv](https://github.com/RundownRhino/aw-watcher-mpv-sender). Early version (no visualizations, etc), but I've been using it for a few days and what's implemented so far seems to be working fine.