### PR TITLE
Updated Windows Data Path

### DIFF
--- a/src/directories.rst
+++ b/src/directories.rst
@@ -8,7 +8,7 @@ Where things get stored depends on the platform you're using. All paths should f
 Data
 ----
 
-- Windows: ``C:\Users\<USER>\AppData\Local\activitywatch\activitywatch``
+- Windows: ``%LocalAppData%\activitywatch\activitywatch``
 - macOS: ``~/Library/Application Support/activitywatch``
 - Linux: ``~/.local/share/activitywatch``
 


### PR DESCRIPTION
Updated Windows Data Path to be consistent with config path:

Old: 
C:\Users\<USER>\AppData\Local\activitywatch\activitywatch

New:
%LocalAppData%\activitywatch\activitywatch