### PR TITLE
docs(watchers): Add reference to aw-watcher-obsidian

### DIFF
--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -32,6 +32,7 @@ Watches the actively edited file and associated metadata like path, language, an
 - :gh:`kostasdizas/aw-watcher-sublime` - Sublime Text 3, by :gh-user:`kostasdizas`, and others
 - :gh:`NicoWeio/aw-watcher-atom` - Atom, by :gh-user:`NicoWeio`
 - :gh:`pytlus93/AwWatcherNetBeans82` - NetBeans 8.2, by :gh-user:`pytlus93`
+- :gh:`LordGrimmauld/aw-watcher-obsidian` - Obsidian.md extension, by :gh-user:`LordGrimmauld`
 
 Media watchers
 --------------


### PR DESCRIPTION
aw-watcher-obsidian is a watcher capable of watching files in the obsidian markdown editor. The watcher is tested under Linux, it might work under windoes/Mac too but i don not have any options to test those.
This is an early version, issues may arise.
The obsidian plugin is open source at https://github.com/LordGrimmauld/aw-watcher-obsidian