### PR TITLE
Add quotes to filepaths in GNOME desktop files suggestion

### DIFF
--- a/src/running-on-gnome.rst
+++ b/src/running-on-gnome.rst
@@ -35,7 +35,7 @@ Then you can create two desktop files for these scripts to show up among your ap
   [Desktop Entry]
   Name=Start ActivityWatch
   Comment=Start AW
-  Exec=~/.local/opt/activitywatch/start.sh
+  Exec="~/.local/opt/activitywatch/start.sh"
   Hidden=false
   Terminal=false
   Type=Application
@@ -50,7 +50,7 @@ Then you can create two desktop files for these scripts to show up among your ap
   [Desktop Entry]
   Name=Kill ActivityWatch
   Comment=Kill AW
-  Exec=~/.local/opt/activitywatch/kill.sh
+  Exec="~/.local/opt/activitywatch/kill.sh"
   Hidden=false
   Terminal=false
   Type=Application


### PR DESCRIPTION
It is needed to place quotes around the filepath because '\~' is used and the desktop file is invalid if '\~' is used outside of quotes. I hope it prevents someone else from running into the same problem.