### PR TITLE
Update watchers.rst to include support for Edge browser

### DIFF
--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -16,7 +16,7 @@ Browser watchers
 
 Watches properties of the active tab like title, URL, and incognito state.
 
-- :gh-aw:`aw-watcher-web` - The official browser extension, supports Chrome, Edge (use Chrome extension) and Firefox.
+- :gh-aw:`aw-watcher-web` - The official browser extension, supports Chrome, Edge, and Firefox.
 
 Editor watchers
 ---------------

--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -16,7 +16,7 @@ Browser watchers
 
 Watches properties of the active tab like title, URL, and incognito state.
 
-- :gh-aw:`aw-watcher-web` - The official browser extension, supports Chrome and Firefox.
+- :gh-aw:`aw-watcher-web` - The official browser extension, supports Chrome, Edge (use Chrome extension) and Firefox.
 
 Editor watchers
 ---------------


### PR DESCRIPTION
Many Chrome extensions will work with Microsoft Edge as it is based on Google Chrome.  This extension has been loaded into the current version of Edge and shows results in ActivityWatch.