### PR TITLE
MacOS data directory typo

### DIFF
--- a/src/directories.rst
+++ b/src/directories.rst
@@ -9,7 +9,7 @@ Data
 ----
 
 - Windows: ``C:\Users\<USER>\AppData\Local\activitywatch\activitywatch``
-- macOS: ``~/Library/Application Support/activitywatch``
+- macOS: ``~/Library/Application/ Support/activitywatch``
 - Linux: ``~/.local/share/activitywatch``
 
 .. _config-directory:

--- a/src/directories.rst
+++ b/src/directories.rst
@@ -9,7 +9,7 @@ Data
 ----
 
 - Windows: ``C:\Users\<USER>\AppData\Local\activitywatch\activitywatch``
-- macOS: ``~/Library/Application/ Support/activitywatch``
+- macOS: ``~/Library/Application\ Support/activitywatch``
 - Linux: ``~/.local/share/activitywatch``
 
 .. _config-directory:


### PR DESCRIPTION
Directory typo fix

Directory with typo: ~/Library/Application Support/activitywatch

Directory fix: ~/Library/Application\ Support/activitywatch

Closes #127 