### PR TITLE
Add aw-watcher-media-player to watchers

### DIFF
--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -43,6 +43,7 @@ If you want to more accurately track media consumption.
 - :gh-aw:`aw-watcher-chromecast` - (not working yet) Watches what is playing on you Chromecast device.
 - :gh-aw:`aw-watcher-openvr` - (not working yet) Watches active VR applications.
 - :gh:`RundownRhino/aw-watcher-mpv-sender` - (WIP) Watches mpv and reports the currently playing video.
+- :gh:`2e3s/aw-watcher-media-player` - Watches the currently playing media which is reported by most players to the system.
 
 Other watchers
 --------------


### PR DESCRIPTION
This covers most media players. I based the idea and format on aw-watcher-spotify, but I wanted to support any player, fortunately there is a way.