### PR TITLE
Fix pessimistic FAQ about Wayland

### DIFF
--- a/src/faq.rst
+++ b/src/faq.rst
@@ -46,7 +46,9 @@ This is a good idea, any application shouldn't just give that privacy-sensitive 
 
 Unfortunately, in Wayland compositors like Gnome's Mutter there is no way at all to get the current window, this leaves the window watcher completely disabled in Wayland.
 
-*Solution:* Switch to using X11 (the best option), and if you can't: bother the developer of your Wayland compositor.
+*Solutions:*
+- Switch to using X11.
+- Try an alternative AFK and window :ref:`watcher <other-watchers>` which supports Wayland.
 
 You can see the general status of the ability of `getting the active window in Wayland on StackOverflow <https://stackoverflow.com/questions/45465016/how-do-i-get-the-active-window-on-gnome-wayland>`_ or follow `the issue for ActivityWatch tracking the problem <https://github.com/ActivityWatch/activitywatch/issues/92>`_.
 

--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -45,6 +45,8 @@ If you want to more accurately track media consumption.
 - :gh:`RundownRhino/aw-watcher-mpv-sender` - (WIP) Watches mpv and reports the currently playing video.
 - :gh:`2e3s/aw-watcher-media-player` - Watches the currently playing media which is reported by most players to the system.
 
+.. _other-watchers:
+
 Other watchers
 --------------
 
@@ -59,7 +61,6 @@ Other watchers to collect all kinds of data.
 - :gh:`Edwardsoen/aw-watcher-steam` - A Watcher to monitor current game being played.
 - :gh:`2e3s/awatcher` - A compiled watcher for X11 and Wayland to replace the original active window and AFK watchers, with workarounds for KDE and Gnome on Wayland.
 - :gh:`RTnhN/aw-watcher-toggl` - A Watcher to import time entries from Toggl.
-- :gh:`flexagoon/aw-watcher-gnome` - A watcher to use ActivityWatch on GNOME with Wayland
 - :gh:`sameersismail/aw-watcher-netstatus` - Monitors if you're connected to a network, by :gh-user:`sameersismail`.
 
 Custom visualizations


### PR DESCRIPTION
FAQ suggests that it's impossible while it's not completely true.

Also, https://github.com/flexagoon/aw-watcher-gnome is deprecated.