### PR TITLE
Add more watchers/importers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         make html
     - name: Upload build
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v4
       with:
         name: build
         path: _build

--- a/src/importers.rst
+++ b/src/importers.rst
@@ -7,6 +7,8 @@ ActivityWatch can't track everything, so sometimes you might want to import data
 - :gh-aw:`aw-importer-smartertime`, imports from `smartertime`_ Useful for importing Android screentime data.(Note ActivityWatch also has an Android app :gh-aw:`aw-android`)
 - :gh-aw:`aw-import-screentime`, attempt at importing from macOS's Screen Time (and potentially iOS through syncing).
 - :gh:`brayo-pip/aw-import-wakatime`, imports from `Wakatime`_ (For tracking time spent programming).
+- :gh:`rtnhn/aw-importer-lastfm`, imports from Last.fm data export (For tracking time spent listening to music).
+- :gh:`rtnhn/aw-importer-lifecycle`, imports from a Lifecycle app export (For tracking time spent in locations).
 
 
 .. _smartertime: https://play.google.com/store/apps/details?id=com.smartertime&hl=en

--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -63,6 +63,7 @@ Other watchers to collect all kinds of data.
 - :gh:`2e3s/awatcher` - A compiled watcher for X11 and Wayland to replace the original active window and AFK watchers, with workarounds for KDE and Gnome on Wayland.
 - :gh:`RTnhN/aw-watcher-toggl` - A Watcher to import time entries from Toggl.
 - :gh:`sameersismail/aw-watcher-netstatus` - Monitors if you're connected to a network, by :gh-user:`sameersismail`.
+- :gh:`RTnhN/aw-watcher-buttons` - (WIP) A watcher for tracking external hardware buttons based on an Arduino used for working state.
 
 Importers
 ---------


### PR DESCRIPTION
This adds three new watchers/importers to the docs:

### Lastfm importer
This simply imports the last.fm data into AW by watching a folder. Since it does not include song duration on the export, I just set the default time to 60 seconds. I think this is maybe even a little more consistent in recording song plays than the Spotify watcher since the Spotify watcher sometimes misses songs. 

### Lifecycle importer
Lifecycle is a great iOS app that tracks location and activity. It also has a really nice export. This is particularly helpful to see what you were doing when you are away from your computer that has AW. This also watches a folder for changes.  

### Buttons watcher
For work related stuff, I have a couple "buckets" that I need to file hours into. While I could just determine that from data in AW, it is nice to just have a clear label to make it obvious what "state" I am in as a check. It is also really satisfying to press a physical button to change "state".  The light up buttons also are a great indicator about what "state" I should be in. The hardware is just an Arduino that talks to the computer though serial. The watcher includes the Arduino code although I might need to add a diagram on how to wire up the buttons to the Arduino (it is really pretty simple though).   

This also fixes the build by updating the Upload Artifact to the newest version.

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9e96412d66b00c15e5e8c67fa71c9c731308be56  | 
|--------|--------|

### Summary:
Added Lastfm, Lifecycle importers, and Buttons watcher to documentation for tracking music, location, and work states.

**Key points**:
- Added `aw-importer-lastfm` to `src/importers.rst` for importing Last.fm data.
- Added `aw-importer-lifecycle` to `src/importers.rst` for importing Lifecycle app data.
- Added `aw-watcher-buttons` to `src/watchers.rst` for tracking work states using Arduino hardware.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->