### PR TITLE
Update ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         make html
     - name: Upload build
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v4
       with:
         name: build
         path: _build

--- a/src/importers.rst
+++ b/src/importers.rst
@@ -7,6 +7,8 @@ ActivityWatch can't track everything, so sometimes you might want to import data
 - :gh-aw:`aw-importer-smartertime`, imports from `smartertime`_ Useful for importing Android screentime data.(Note ActivityWatch also has an Android app :gh-aw:`aw-android`)
 - :gh-aw:`aw-import-screentime`, attempt at importing from macOS's Screen Time (and potentially iOS through syncing).
 - :gh:`brayo-pip/aw-import-wakatime`, imports from `Wakatime`_ (For tracking time spent programming).
+- :gh:`rtnhn/aw-importer-lastfm`, imports from Last.fm data export (For tracking time spent listening to music).
+- :gh:`rtnhn/aw-importer-lifecycle`, imports from a Lifecycle app export (For tracking time spent in locations).
 
 
 .. _smartertime: https://play.google.com/store/apps/details?id=com.smartertime&hl=en

--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -63,6 +63,7 @@ Other watchers to collect all kinds of data.
 - :gh:`2e3s/awatcher` - A compiled watcher for X11 and Wayland to replace the original active window and AFK watchers, with workarounds for KDE and Gnome on Wayland.
 - :gh:`RTnhN/aw-watcher-toggl` - A Watcher to import time entries from Toggl.
 - :gh:`sameersismail/aw-watcher-netstatus` - Monitors if you're connected to a network, by :gh-user:`sameersismail`.
+- :gh:`RTnhN/aw-watcher-buttons` - (WIP) A watcher for tracking external hardware buttons based on an Arduino used for working state.
 
 Importers
 ---------


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ecb6e2bdb59283fd8ac4d1d0268291d2aa3d0c97  | 
|--------|--------|

### Summary:
Updated CI workflow and documentation for new importers and watchers.

**Key points**:
- Updated `.github/workflows/build.yml` to use `actions/upload-artifact@v4` instead of `v2-preview`.
- Added `rtnhn/aw-importer-lastfm` and `rtnhn/aw-importer-lifecycle` to `src/importers.rst` for importing Last.fm and Lifecycle app data.
- Added `RTnhN/aw-watcher-buttons` to `src/watchers.rst` for tracking external hardware buttons.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->