### PR TITLE
fix GNOME desktop entry instructions

### DIFF
--- a/src/running-on-gnome.rst
+++ b/src/running-on-gnome.rst
@@ -28,7 +28,7 @@ As an alternative for users of GNOME 3 and other desktop environments that don't
 
 Don't forget to :code:`chmod +x start.sh` and :code:`chmod +x kill.sh`.
 
-Then you can create two desktop files for these scripts to show up among your apps:
+Then you can create two desktop files for these scripts to show up among your apps. Be sure to substitute `user` for your own username:
 
 :code:`~/.local/share/applications/aw-start.desktop`:
 ::
@@ -36,7 +36,7 @@ Then you can create two desktop files for these scripts to show up among your ap
   [Desktop Entry]
   Name=Start ActivityWatch
   Comment=Start AW
-  Exec="~/.local/opt/activitywatch/start.sh"
+  Exec="/home/user/.local/opt/activitywatch/start.sh"
   Hidden=false
   Terminal=false
   Type=Application
@@ -51,7 +51,7 @@ Then you can create two desktop files for these scripts to show up among your ap
   [Desktop Entry]
   Name=Kill ActivityWatch
   Comment=Kill AW
-  Exec="~/.local/opt/activitywatch/kill.sh"
+  Exec="/home/user/.local/opt/activitywatch/kill.sh"
   Hidden=false
   Terminal=false
   Type=Application


### PR DESCRIPTION
Gotta use absolute paths in `Exec` in `.desktop` files or they don't show up automatically. Not sure if this is true for everyone/always, but it was for me.

Sources:

https://bbs.archlinux.org/viewtopic.php?id=256867

https://discourse.gnome.org/t/application-entries-desktop-not-displayed/3670

https://discussion.fedoraproject.org/t/how-to-create-a-desktop-file-to-show-up-among-my-apps/128596/5

These sources indicate the underlying issue appears has to do with an issue with the user's non-interactive path, but I think the issue might actually be the tilde is not expanded. I didn't attempt to debug further, I just used an absolute path and it worked (they immediately started showing up when I press the "Super" key). Using an absolute path seems like the safer (and more annoying) way to go to make it work for most people. I do wish tilde worked more reliably.

FFR, my desktop right now is GNOME, as shipped with 64-bit Ubuntu 22.04 LTS. I think that means GNOME 3 and Wayland.