### PR TITLE
Add zed watcher

### DIFF
--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -45,6 +45,7 @@ Watches the actively edited file and associated metadata like path, language, an
 - :gh:`pytlus93/AwWatcherNetBeans82` - NetBeans 8.2, by :gh-user:`pytlus93`
 - :gh:`LordGrimmauld/aw-watcher-obsidian` - Obsidian.md extension, by :gh-user:`LordGrimmauld`
 - :gh:`lowitea/aw-watcher.nvim` - neovim extension, by :gh-user:`lowitea`.
+- :gh:`sachk/aw-watcher-zed` - Zed extension, by :gh-user:`sachk`.
 
 Media watchers
 --------------


### PR DESCRIPTION
I wrote a watcher for Zed, which I've published on zed's official extension store now

https://github.com/sachk/aw-watcher-zed


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `sachk/aw-watcher-zed` to `watchers.rst` under Editor watchers.
> 
>   - **Documentation**:
>     - Add `sachk/aw-watcher-zed` to `watchers.rst` under Editor watchers, indicating a new Zed extension by `sachk`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 48152c62c36a6448db8a06a8ae43eb9053d70de7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->