### PR TITLE
Document modules for supporting Wayland more clearly

### DIFF
--- a/src/getting-started.rst
+++ b/src/getting-started.rst
@@ -33,6 +33,9 @@ Installation
       .. note::
          Getting it to F-droid is a work-in-progress, see `this PR <https://gitlab.com/fdroid/fdroiddata/-/merge_requests/5502>`_.
 
+   .. group-tab:: Source
+
+      If you prefer to build ActivityWatch from source, check out :doc:`this guide <installing-from-source>` instead.
 
 Usage
 =====

--- a/src/getting-started.rst
+++ b/src/getting-started.rst
@@ -37,6 +37,7 @@ Installation
 
       If you prefer to build ActivityWatch from source, check out :doc:`this guide <installing-from-source>` instead.
 
+
 Usage
 =====
 
@@ -50,6 +51,9 @@ If you want more advanced ways to run ActivityWatch (including running it withou
 
 .. note::
    If you are running GNOME 3 or another desktop environment that does not support system trays, or if for some reason Qt can't be used on your machine, read `Running on GNOME`.
+
+.. note::
+   If your Linux system is using Wayland rather than X11, the default watchers will not work. Read :ref:`window and idle watchers for Wayland<wayland-watchers>`.
 
 .. note::
    If you are using a proxy ActivityWatch might not work out of the box. To fix this you can set the environment variable ``NO_PROXY`` to include ``127.0.0.1`` before starting aw-qt. How to set an environment variable depends on your operating system; use Google if you are unsure how to do this.

--- a/src/installing-from-source.rst
+++ b/src/installing-from-source.rst
@@ -28,6 +28,9 @@ If you want to ensure you have the latest version of all submodules, preserving 
 
    git submodule foreach --recursive git pull
 
+.. note::
+   If your Linux system is using Wayland rather than X11, the default watchers will not work. Read :ref:`window and idle watchers for Wayland<wayland-watchers>` for replacement modules supporting Wayland.
+
 Checking dependencies
 ---------------------
 

--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -3,7 +3,7 @@ Watchers
 
 Watchers are the parts of ActivityWatch that do all the data collecting.
 
-ActivityWatch comes with two watchers enabled by default:
+ActivityWatch comes with two watchers enabled by default supporting Windows, macOS and Linux (X11 only):
 
 - :gh-aw:`aw-watcher-afk` - Watches for mouse & keyboard activity to detect if the user is active (by default, an inactive period of at least 3 minutes is flagged as AFK: away from keyboard).
 - :gh-aw:`aw-watcher-window` - Watches the active window, its title, and it's url (on Chrome-based browsers & Safari).
@@ -11,16 +11,19 @@ ActivityWatch comes with two watchers enabled by default:
 These default watchers are collecting some of the most important data.
 But there is more to collect, so here are some other watchers that let you do so.
 
-.. _window-watchers:
+.. note::
+   For Wayland, see :ref:`wayland-watchers`.
 
-Window watchers
----------------
+.. _wayland-watchers:
 
-Watches the active window, its title, and application name.
+Window and idle watchers for Wayland
+-------------------------------------------
 
-- :gh-aw:`aw-watcher-window` - The official window watcher for Windows, macOS, and Linux (X11 only).
-- :gh-aw:`aw-watcher-window-wayland` - A window watcher for Wayland, by :gh-user:`johan-bjareholt`.
-- :gh:`2e3s/awatcher` - A compiled watcher for X11 and Wayland to replace default window and AFK watchers, by :gh-user:`2e3s`.
+Replaces :gh-aw:`aw-watcher-window` and :gh-aw:`aw-watcher-afk` to support Wayland, see issue :issue:`92`.
+
+- :gh-aw:`aw-watcher-window-wayland` - A window and idle watcher for Wayland, by :gh-user:`johan-bjareholt`, supports Posh, Sway.
+- :gh:`2e3s/awatcher` - A compiled window and idle watcher for X11 and Wayland to replace default window and AFK watchers,
+  by :gh-user:`2e3s`, supports Sway, Hyprland, KDE, GNOME, and X11.
 
 Browser watchers
 ----------------


### PR DESCRIPTION
The following information is easy to miss:
- Wayland not yet supported by [aw-watcher-window or aw-watcher-afk](https://github.com/ActivityWatch/activitywatch/issues/92).
- Wayland (Posh, Sway) is supported by [aw-watcher-wayland](https://github.com/activitywatch/aw-watcher-window-wayland) (window+afk).
- Wayland (Sway, Hyprland, KDE, GNOME, and X11) is supported by [awatcher](https://github.com/2e3s/awatcher).

Wayland users are likely to burn themselves once or twice before realising the default watchers are not supported. Currently is hinted with `(X11 only)` in the "Window Watchers" section of `watchers.rst`, which users may not think to check, so I added a note on the "Getting Started" and "Installing from Source" pages. Information that the `aw-watcher-window-wayland` doesn't work on KDE or Gnome is also not clear, so I added a list of the supported DE in brackets.

Also I linked to "building from source" as an installation option. At the moment it is only linked to from "Usage", which is less intuitive.