### PR TITLE
ci: bump python version to 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Install APT dependencies
       run: |
         sudo apt-get install -y git build-essential apt-utils wget libfreetype6 libpng-dev libopenblas-dev gcc gfortran libsnappy-dev


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Python version to 3.13 in GitHub Actions workflow for CI/CD pipeline.
> 
>   - **CI/CD**:
>     - Update Python version from 3.8 to 3.13 in `.github/workflows/build.yml` for the `Set up Python` step.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 223ea08252240c1e6b108469ab254ab1d23c8898. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->