### PR TITLE
Deprecated the Obsidian watcher in favor of the AW plugin for Obsidian

### DIFF
--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -43,7 +43,11 @@ Watches the actively edited file and associated metadata like path, language, an
 - :gh:`kostasdizas/aw-watcher-sublime` - Sublime Text 3, by :gh-user:`kostasdizas`, and others
 - :gh:`NicoWeio/aw-watcher-atom` - Atom, by :gh-user:`NicoWeio`
 - :gh:`pytlus93/AwWatcherNetBeans82` - NetBeans 8.2, by :gh-user:`pytlus93`
-- :gh:`LordGrimmauld/aw-watcher-obsidian` - Obsidian.md extension, by :gh-user:`LordGrimmauld`
+- .. raw:: html
+
+     <s>:gh:`LordGrimmauld/aw-watcher-obsidian` - Obsidian.md extension, by :gh-user:`LordGrimmauld`</s> (Deprecated, use the modern method below)
+
+  - **Recommended**: Install the ActivityWatch community plugin for Obsidian
 - :gh:`lowitea/aw-watcher.nvim` - neovim extension, by :gh-user:`lowitea`.
 - :gh:`sachk/aw-watcher-zed` - Zed extension, by :gh-user:`sachk`.
 


### PR DESCRIPTION
The Obsidian watcher seems to be dead, with the latest commit being 2 years ago and several issues mentioning it is broken.
By contrast, the ActivityWatch plugin for Obsidian works fine and does the exact same thing, just by having Obsidian push the information to AW instead of having AW watch for it.

This PR adds this information
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Deprecated `aw-watcher-obsidian` in favor of the ActivityWatch plugin for Obsidian in `watchers.rst`.
> 
>   - **Deprecation**:
>     - Deprecated `aw-watcher-obsidian` in `watchers.rst`.
>     - Added recommendation to use the ActivityWatch community plugin for Obsidian.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Fdocs&utm_source=github&utm_medium=referral)<sup> for b3312e2c998c52ce78358dc0aa92e36ea66e866d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->