### PR TITLE
watchers: add aw-watcher-window-hyprland

### DIFF
--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -21,6 +21,7 @@ Watches the active window, its title, and application name.
 - :gh-aw:`aw-watcher-window` - The official window watcher for Windows, macOS, and Linux (X11 only).
 - :gh-aw:`aw-watcher-window-wayland` - A window watcher for Wayland, by :gh-user:`johan-bjareholt`.
 - :gh:`2e3s/awatcher` - A compiled watcher for X11 and Wayland to replace default window and AFK watchers, by :gh-user:`2e3s`.
+- :gh-aw:`aw-watcher-window-hyprland` - A window watcher for Hyprland, by :gh-user:`bobvanderlinden`.
 
 Browser watchers
 ----------------


### PR DESCRIPTION
As suggested [on the forum](https://forum.activitywatch.net/t/hyprland-watcher/3977/2?u=bobvanderlinden), this adds aw-watcher-window-hyprland to the docs.