### PR TITLE
Add link in query docs to code showing all available query functions

### DIFF
--- a/src/examples/querying-data.rst
+++ b/src/examples/querying-data.rst
@@ -15,6 +15,7 @@ Writing a Query
 .. note::
     This section is still WIP.
     There is still no documentation of all the transform functions, but for most simple queries these examples should be enough.
+    For complex queries, you can see all available functions here: https://github.com/ActivityWatch/aw-server-rust/blob/master/aw-query/src/functions.rs
 
 Queries are the easiest yet advanced way to get events from aw-server buckets in a format which fits most needs.
 Queries can be done by doing a POST request to aw-server either manually or with the aw-client library.


### PR DESCRIPTION
The examples don't show many of the functions available. Added a link in the docs to the code where the functions are defined.