### PR TITLE
docs: add Foqos importer

### DIFF
--- a/src/importers.rst
+++ b/src/importers.rst
@@ -8,8 +8,11 @@ ActivityWatch can't track everything, so sometimes you might want to import data
 - :gh-aw:`aw-import-screentime`, attempt at importing from macOS's Screen Time (and potentially iOS through syncing).
 - :gh:`0xbrayo/aw-import-wakatime`, imports from `Wakatime`_ (For tracking time spent programming).
 - :gh:`rtnhn/aw-importer-lastfm`, imports from Last.fm data export (For tracking time spent listening to music).
-- :gh:`rtnhn/aw-importer-lifecycle`, imports from a Lifecycle app export (For tracking time spent in locations).
+- :gh:`rtnhn/aw-importer-lifecycle`, imports from a `Lifecycle`_ app export (For tracking time spent in locations).
+- :gh:`rtnhn/aw-importer-foqos`, imports from a `Foqos`_ export (For tracking screentime breaks from the Foqos app).
 
 
 .. _smartertime: https://play.google.com/store/apps/details?id=com.smartertime&hl=en
 .. _Wakatime: https://wakatime.com/	
+.. _Lifecycle: https://apps.apple.com/us/app/life-cycle-track-your-time/id1064955217
+.. _Foqos: https://www.foqos.app/


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `aw-importer-foqos` to `importers.rst` for Foqos app screentime break imports.
> 
>   - **Documentation**:
>     - Adds `aw-importer-foqos` to `importers.rst` for importing screentime breaks from the Foqos app.
>     - Adds reference link for `Foqos` in `importers.rst`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Fdocs&utm_source=github&utm_medium=referral)<sup> for e7735bbdcc5b4fa14df45ecd9f8518030f93466b. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->