### PR TITLE
Add tip for absolute Exec path in documentation

### DIFF
--- a/src/running-on-gnome.rst
+++ b/src/running-on-gnome.rst
@@ -60,7 +60,7 @@ Then you can create two desktop files for these scripts to show up among your ap
   Categories=Utility;
 
 .. tip::
-  You will most likely have to replace the :code:`Exec` relative path with an absolute one. 
+  You will most likely have to replace the :code:`Exec` path using the `~` shorthand with a full absolute path, as `~` is not expanded in desktop files.
   That is:
 
   :code:`Exec="~/.local/opt/activitywatch/kill.sh"`


### PR DESCRIPTION
Added a tip about replacing the Exec path with an absolute one in the running-on-gnome documentation.

Sometime in the last 2 years seems like absolute path is required.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a documentation tip in `running-on-gnome.rst` for using absolute paths in `Exec` entries for GNOME desktop files.
> 
>   - **Documentation**:
>     - Adds a tip in `running-on-gnome.rst` to replace `Exec` relative paths with absolute paths in GNOME desktop files.
>     - Example provided for changing `Exec="~/.local/opt/activitywatch/kill.sh"` to `Exec="/home/<your-username>/.local/opt/activitywatch/kill.sh"`.
>     - Clarifies the need to replace `<your-username>` with the actual username.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 3a7f2d28c39385bee30a19c3a681060951c71d3e. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->