### PR TITLE
feat: link pages to GitHub source

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -182,6 +182,13 @@ elif THEME_RTD:
 
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     html_theme_options = {"collapse_navigation": False, "navigation_depth": 4}
+    html_context = {
+        "display_github": True,
+        "github_user": "ActivityWatch",
+        "github_repo": "docs",
+        "github_version": "master",
+        "conf_py_path": "/src/",
+    }
     using_rtd_theme = True
 
 # The name for this set of Sphinx documents.


### PR DESCRIPTION
Addresses #158

Tested locally:
<img width="938" height="494" alt="image" src="https://github.com/user-attachments/assets/aadad376-3077-4fe7-8e57-3395071cc7fa" />

... In this case, the link from https://docs.activitywatch.net/en/latest/introduction.html leads to https://github.com/ActivityWatch/docs/blob/master/src/introduction.rst
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds GitHub source linking to documentation pages by configuring `html_context` in `conf.py`.
> 
>   - **Behavior**:
>     - Adds `html_context` in `conf.py` to enable linking pages to GitHub source.
>     - Links point to `ActivityWatch/docs` repository on `master` branch.
>   - **Configuration**:
>     - Sets `display_github`, `github_user`, `github_repo`, `github_version`, and `conf_py_path` in `html_context` for Sphinx RTD theme.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Fdocs&utm_source=github&utm_medium=referral)<sup> for b60375cbb799ffcb0a3fd92555148b8e64702dc8. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->