### PR TITLE
`architecture.rst`: add `aw-server-rust`, misc. cleanup

### DIFF
--- a/src/_static/css/custom.css
+++ b/src/_static/css/custom.css
@@ -15,6 +15,10 @@ code {
     color: rgb(51, 51, 51);
 }
 
+.rst-content code.literal, .rst-content tt.literal {
+    color: #a34400;
+}
+
 .rst-content .section ul p {
     margin-bottom: 0px !important;
 }

--- a/src/architecture.rst
+++ b/src/architecture.rst
@@ -15,16 +15,23 @@ The illustration below is a graph of the fundamental dependencies between projec
 Server
 ------
 
-Known as :gh-aw:`aw-server`, it handles storage and retrieval of all activities/entries in buckets. Usually there exists one bucket per watcher.
+ActivityWatch has two server implementations:
 
-The server also hosts the Web UI (aw-webui) which does all communication with the server using the REST API.
+- :gh-aw:`aw-server` - The current default Python implementation
+- :gh-aw:`aw-server-rust` - A Rust implementation that is the planned future default
 
-Clients (watchers, importers, and observers)
---------------------------------------------
+The server handles storage and retrieval of all activities/entries in buckets. Usually there exists one bucket per watcher.
 
-Since aw-server doesn't do any data collection on it's own, we need watchers that observe the world and sent the data off to aw-server for storage.
+The server also hosts the Web UI (``aw-webui``) which does all communication with the server using the REST API.
 
-These utilize the aw-client library for making requests to the aw-server.
+Clients (watchers and importers)
+--------------------------------
+
+Since ``aw-server`` doesn't do any data collection on it's own, we need watchers that observe the world and sent the data off to ``aw-server`` for storage.
+
+These utilize the ``aw-client`` library for making requests to the ``aw-server``.
+
+ActivityWatch can't track everything, so sometimes you might want to import data from another source, that's where importers come in.
 
 For a list of watchers, see :doc:`watchers`. For a list of importers see :doc:`importers`.
 
@@ -32,40 +39,40 @@ For a list of watchers, see :doc:`watchers`. For a list of importers see :doc:`i
 User interfaces
 ---------------
 
-ActivityWatch currently has two user interfaces, aw-qt and aw-webui.
+ActivityWatch currently has two user interfaces, ``aw-qt`` and ``aw-webui``.
 
 - :gh-aw:`aw-qt` - Manages the server and watchers to make ActivityWatch easy to use for end-users.
-- :gh-aw:`aw-webui` - Offers visualization and an overview of the database. Hosted by aw-server in the bundle.
+- :gh-aw:`aw-webui` - Offers visualization and an overview of the database. Hosted by ``aw-server`` in the bundle.
 
 Libraries
 ---------
 
 Some of the logic of ActivityWatch is shared across the server and clients, for these cases we moved some logic into separate libraries.
 
-aw-core
-^^^^^^^
+:gh-aw:`aw-core`
+^^^^^^^^^^^^^^^^
 
-The aw-core library contains many of the essential parts of ActivityWatch, notably:
+The ``aw-core`` library contains many of the essential parts of ActivityWatch, notably:
 
 - The `buckets-and-events`
 - The datastore layer
 - Event transformation and queries
 - Utilities (configuration, logging, decorators)
 
-aw-client
-^^^^^^^^^
+:gh-aw:`aw-client`
+^^^^^^^^^^^^^^^^^^
 
 Writing these clients is something we've tried to make as easy as possible by creating client libraries with a clear API.
-A client could both be a watcher which sends data as well as a visualizer which fetches and presents data from the aw-server.
+A client could both be a watcher which sends data as well as a visualizer which fetches and presents data from the ``aw-server``.
 
-Currently the primary client library is written in Python (known simply as aw-client) but a client library written in JavaScript is on the way and is expected to have the same level of support in the future.
+Currently the primary client library is written in Python (known simply as ``aw-client``) but a client library written in JavaScript is on the way and is expected to have the same level of support in the future.
 
 - :gh-aw:`aw-client` (Python)
 - :gh-aw:`aw-client-js` (TypeScript/JavaScript, beta)
 - :gh-aw:`aw-client-rust <aw-server-rust/tree/master/aw-client-rust>` (Rust, work in progress)
 
-aw-analysis
-^^^^^^^^^^^
+:gh-aw:`aw-research`
+^^^^^^^^^^^^^^^^^^^^
 
-There are also plans to create a library called :gh-aw:`aw-analysis` to aid in
+There are also plans to create a library called ``aw-research`` to aid in
 different types of analysis and transformation one might want to make using ActivityWatch data.


### PR DESCRIPTION
1. `architecture.rst`:
    - Servers: added `aw-server-rust`
    - Clients: dropped mention of "observers" and clarified role of "importers"
    - `aw-analysis` seems to have been renamed to `aw-research`
    - misc. cleanup

3. `custom.css`: make inline `<code>` look less alarming
    - Default is `#e74c3c` which reads like "error", changed to a dark orange which seems more neutral, but still "sticks out" enough for skimming purposes.

<img width="1448" height="3186" alt="image" src="https://github.com/user-attachments/assets/e60e26e6-7f9e-4383-b8bc-a0a1f210d7b7" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `architecture.rst` to include `aw-server-rust`, clarify client roles, rename `aw-analysis` to `aw-research`, and modifies `custom.css` for better inline code readability.
> 
>   - **`architecture.rst` Updates**:
>     - Added `aw-server-rust` to server implementations.
>     - Clarified client roles by removing "observers" and explaining "importers".
>     - Renamed `aw-analysis` to `aw-research`.
>     - General cleanup for clarity.
>   - **`custom.css` Changes**:
>     - Changed inline `<code>` color from `#e74c3c` to `#a34400` for a less alarming appearance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 00baaccf91106cc4b508af857e315b702d77fedc. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->