### PR TITLE
docs: fix typo in syncing.rst

### DIFF
--- a/src/syncing.rst
+++ b/src/syncing.rst
@@ -5,7 +5,7 @@ Syncing
 
     This feature is currently in beta and may change in future releases.
 
-ActivityWatch has basic support for syncing your data across multiple devices using the ``aw-sync`` module since ``v0.13.0``. It works by creating a "staging" database file in a device-specific folder in the sync directory (default is ``~/ActivityWatchSync``), which is then synced to the other devices using a file syncing tool of your choice (like Syncthing, rsync, Dropbox, or Google Drive). So ``aw-sync`` does itself send data over the network, but instead relies on you using a file syncing tool to do that.
+ActivityWatch has basic support for syncing your data across multiple devices using the ``aw-sync`` module since ``v0.13.0``. It works by creating a "staging" database file in a device-specific folder in the sync directory (default is ``~/ActivityWatchSync``), which is then synced to the other devices using a file syncing tool of your choice (like Syncthing, rsync, Dropbox, or Google Drive). So ``aw-sync`` does not itself send data over the network, but instead relies on you using a file syncing tool to do that.
 
 Note that syncing is not available on Android, yet.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typo in `syncing.rst`, changing 'does' to 'does not' in `aw-sync` description.
> 
>   - **Documentation**:
>     - Fix typo in `syncing.rst`, changing 'does' to 'does not' in the description of `aw-sync` functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 47ed5ed93cd4dade9e0f6b9f7569d0e649a8748c. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->