### PR TITLE
docs: clarify macOS release-specific support guidance

### DIFF
--- a/src/faq.rst
+++ b/src/faq.rst
@@ -17,7 +17,7 @@ Yes. ActivityWatch is completely free and open-source software, licensed under t
 What platforms does ActivityWatch support?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-ActivityWatch runs on **Windows**, **macOS**, **Linux**, and **Android**. Browser extensions are available for Chrome, Firefox, and Edge to track your web activity. macOS version and architecture support varies by release, so if you need a specific macOS build check the `downloads page <https://activitywatch.net/downloads/>`_ or the GitHub release assets.
+ActivityWatch runs on **Windows**, **macOS**, **Linux**, and **Android**. Browser extensions are available for Chrome, Firefox, and Edge to track your web activity. macOS version and architecture support varies by release, so if you need a specific macOS build check the `downloads page <https://activitywatch.net/downloads/>`_ or the `GitHub release assets <https://github.com/ActivityWatch/activitywatch/releases>`_.
 
 Does ActivityWatch track my data privately?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/faq.rst
+++ b/src/faq.rst
@@ -17,7 +17,7 @@ Yes. ActivityWatch is completely free and open-source software, licensed under t
 What platforms does ActivityWatch support?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-ActivityWatch runs on **Windows** (10 and later), **macOS** (10.15+), **Linux** (most distributions), and **Android**. Browser extensions are available for Chrome, Firefox, and Edge to track your web activity.
+ActivityWatch runs on **Windows**, **macOS**, **Linux**, and **Android**. Browser extensions are available for Chrome, Firefox, and Edge to track your web activity. macOS version and architecture support varies by release, so if you need a specific macOS build check the `downloads page <https://activitywatch.net/downloads/>`_ or the GitHub release assets.
 
 Does ActivityWatch track my data privately?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary
- update the FAQ platform-support answer to stop claiming a single `macOS 10.15+` floor
- point readers at the downloads page and release assets for exact macOS build compatibility

## Why
`ActivityWatch/activitywatch#1294` surfaced that the public docs still promised `macOS 10.15+`, but current macOS support varies across release lines.

## Impact
The FAQ no longer gives Catalina/Intel users a false expectation about every current macOS build.

## Validation
- confirmed the stale `10.15+` copy in `src/faq.rst` before editing
- inspected release assets for `ActivityWatch/activitywatch`
- verified the stable `v0.13.2` macOS `x86_64` binary advertises `LC_VERSION_MIN_MACOSX 10.13.0`
- verified the prerelease `v0.14.0b1` macOS `arm64` binary advertises `LC_BUILD_VERSION minos 11.0.0`

Related to ActivityWatch/activitywatch#1294.
