### PR TITLE
docs(syncing): describe current Android sync state

### DIFF
--- a/src/syncing.rst
+++ b/src/syncing.rst
@@ -18,8 +18,8 @@ app's private storage: ``Android/data/net.activitywatch.android/files/sync/``),
 but since Android 11 that directory is not accessible to other apps — so a
 file syncing tool like Syncthing cannot read from or write into it. In
 practice this means the app can produce its side of the sync data, but there
-is currently no supported way to get that data off the phone (pull from other
-devices) or onto it. Automatic background sync used to run unconditionally
+is currently no supported way to push that data to other devices or to pull
+other devices' data onto the phone. Automatic background sync used to run unconditionally
 every 15 minutes regardless of whether it could do anything useful; it is now
 gated behind a preference that defaults to off, so it no longer runs on fresh
 installs.

--- a/src/syncing.rst
+++ b/src/syncing.rst
@@ -7,7 +7,27 @@ Syncing
 
 ActivityWatch has basic support for syncing your data across multiple devices using the ``aw-sync`` module since ``v0.13.0``. It works by creating a "staging" database file in a device-specific folder in the sync directory (default is ``~/ActivityWatchSync``), which is then synced to the other devices using a file syncing tool of your choice (like Syncthing, rsync, Dropbox, or Google Drive). So ``aw-sync`` does not itself send data over the network, but instead relies on you using a file syncing tool to do that.
 
-Note that syncing is not available on Android, yet.
+Android
+-------
+
+Sync on Android is more limited than on desktop, and is currently **disabled
+by default** with no user-facing way to turn it on.
+
+The Android app can push its own events into a sync directory (scoped to the
+app's private storage: ``Android/data/net.activitywatch.android/files/sync/``),
+but since Android 11 that directory is not accessible to other apps — so a
+file syncing tool like Syncthing cannot read from or write into it. In
+practice this means the app can produce its side of the sync data, but there
+is currently no supported way to get that data off the phone (pull from other
+devices) or onto it. Automatic background sync used to run unconditionally
+every 15 minutes regardless of whether it could do anything useful; it is now
+gated behind a preference that defaults to off, so it no longer runs on fresh
+installs.
+
+A proper setup flow — a settings toggle plus a way to pick a sync directory
+that's actually accessible to a file syncing tool (e.g. via Android's Storage
+Access Framework) — is planned but not yet built. Track progress in
+`activitywatch#1357 <https://github.com/ActivityWatch/activitywatch/issues/1357>`_.
 
 How to set up syncing
 ---------------------


### PR DESCRIPTION
## Summary

Replaces the stale "Note that syncing is not available on Android, yet." line
with an accurate description of the current state, per ActivityWatch/activitywatch#1357:

- Push works but pull is a no-op (scoped storage since Android 11 blocks
  Syncthing/etc. from reading the app's sync dir).
- Automatic sync is now off by default (ActivityWatch/aw-android#184, merged),
  with no user-facing toggle yet.
- Links to activitywatch#1357, which tracks the follow-up setup flow (Storage
  Access Framework directory picker + settings UI).

## Related

- ActivityWatch/activitywatch#1357
- ActivityWatch/aw-android#184