### PR TITLE
docs(watchers): list aw-watcher-ask-away and aw-watcher-checkin

### DIFF
--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -72,7 +72,7 @@ Other watchers to collect all kinds of data.
 - :gh:`akohlbecker/aw-watcher-tmux` - A plugin for tmux that allows monitoring activity in sessions and panes, by :gh-user:`akohlbecker`
 - :gh:`bcbernardo/aw-watcher-ask` - (WIP) Periodically poses questions to the user and records her answers.
 - :gh:`Jeremiah-England/aw-watcher-ask-away` - Asks what you were doing when you return from an AFK break, and logs it as the AFK period, by :gh-user:`Jeremiah-England`.
-- :gh-aw:`aw-watcher-checkin` - (WIP) Boundary-triggered check-ins: rate the block you just finished when you return from AFK, switch context, or end a long block. Adopted from :gh:`Jeremiah-England/aw-watcher-ask-away` with full history, by :gh-user:`Jeremiah-England`.
+- :gh-aw:`aw-watcher-checkin` - (WIP) Adopted from :gh:`Jeremiah-England/aw-watcher-ask-away` with full history, by :gh-user:`Jeremiah-England`. Currently the AFK-return prompt; context-switch and long-block check-ins are planned.
 - :gh:`Alwinator/aw-watcher-utilization` - Monitors CPU, RAM, disk, network, and sensor usage, by :gh-user:`Alwinator`
 - :gh:`abdnh/aw-watcher-anki` - An add-on for Anki that tracks time spent reviewing cards.
 - :gh:`Edwardsoen/aw-watcher-steam` - A Watcher to monitor current game being played.

--- a/src/watchers.rst
+++ b/src/watchers.rst
@@ -71,6 +71,8 @@ Other watchers to collect all kinds of data.
 - :gh:`Alwinator/aw-watcher-table` - Monitors whether you have set your height-adjustable table to sitting or standing, by :gh-user:`Alwinator`
 - :gh:`akohlbecker/aw-watcher-tmux` - A plugin for tmux that allows monitoring activity in sessions and panes, by :gh-user:`akohlbecker`
 - :gh:`bcbernardo/aw-watcher-ask` - (WIP) Periodically poses questions to the user and records her answers.
+- :gh:`Jeremiah-England/aw-watcher-ask-away` - Asks what you were doing when you return from an AFK break, and logs it as the AFK period, by :gh-user:`Jeremiah-England`.
+- :gh-aw:`aw-watcher-checkin` - (WIP) Boundary-triggered check-ins: rate the block you just finished when you return from AFK, switch context, or end a long block. Adopted from :gh:`Jeremiah-England/aw-watcher-ask-away` with full history, by :gh-user:`Jeremiah-England`.
 - :gh:`Alwinator/aw-watcher-utilization` - Monitors CPU, RAM, disk, network, and sensor usage, by :gh-user:`Alwinator`
 - :gh:`abdnh/aw-watcher-anki` - An add-on for Anki that tracks time spent reviewing cards.
 - :gh:`Edwardsoen/aw-watcher-steam` - A Watcher to monitor current game being played.


### PR DESCRIPTION
Adds two entries under *Other watchers*, next to the existing `aw-watcher-ask` line:

- [`Jeremiah-England/aw-watcher-ask-away`](https://github.com/Jeremiah-England/aw-watcher-ask-away) — asks what you were doing when you return from an AFK break and logs it as the AFK period. Was not listed.
- [`ActivityWatch/aw-watcher-checkin`](https://github.com/ActivityWatch/aw-watcher-checkin) — the org adoption of the above (full history preserved, attribution in-repo), to be extended with boundary-triggered check-ins. Marked WIP.

Requested by @ErikBjare as part of adopting `aw-watcher-ask-away` into the org.